### PR TITLE
add binary_async_mode rosparam

### DIFF
--- a/include/imu_vn_100/imu_vn_100.h
+++ b/include/imu_vn_100/imu_vn_100.h
@@ -145,6 +145,8 @@ class ImuVn100 {
   ros::Duration imu_timestamp_offset_;
   
   int queue_size_ = 1;
+  uint16_t binary_async_mode_ = BINARY_ASYNC_MODE_SERIAL_1;
+  std::string binary_async_mode_input_ = "SERIAL_1";
 
   du::Updater updater_;
   DiagnosedPublisher pd_imu_, pd_mag_, pd_pres_, pd_temp_;

--- a/launch/vn_100_cont.launch
+++ b/launch/vn_100_cont.launch
@@ -16,6 +16,8 @@
 
     <arg name="binary_output" default="true"/>
 
+    <arg name="binary_async_mode" default="SERIAL_1"/>
+
     <!-- Ros Topic settings -->
     <arg name="enable_mag" default="true"/>
     <arg name="enable_pres" default="true"/>
@@ -33,5 +35,6 @@
         <param name="enable_temp" type="bool" value="$(arg enable_temp)"/>
         <param name="sync_rate" type="int" value="$(arg sync_rate)"/>
         <param name="sync_pulse_width_us" type="int" value="$(arg sync_pulse_width_us)"/>
+        <param name="binary_async_mode" type="string" value="$(arg binary_async_mode)"/>
     </node>
 </launch>

--- a/src/imu_vn_100.cpp
+++ b/src/imu_vn_100.cpp
@@ -123,6 +123,16 @@ void ImuVn100::LoadParameters() {
 
   pnh_.param("queue_size", queue_size_, 1);
 
+  pnh_.param<std::string>("binary_async_mode", binary_async_mode_input_, "SERIAL_1");
+  if (binary_async_mode_input_ == "SERIAL_1")
+  {
+    binary_async_mode_ = BINARY_ASYNC_MODE_SERIAL_1;
+  }
+  else if (binary_async_mode_input_ == "SERIAL_2")
+  {
+    binary_async_mode_ = BINARY_ASYNC_MODE_SERIAL_2;
+  }
+
   FixImuRate();
   sync_info_.FixSyncRate();
 }
@@ -222,7 +232,7 @@ void ImuVn100::Stream(bool async) {
     if (binary_output_) {
       // Set the binary output data type and data rate
       VnEnsure(vn100_setBinaryOutput1Configuration(
-          &imu_, BINARY_ASYNC_MODE_SERIAL_1, kBaseImuRate / imu_rate_,
+          &imu_, binary_async_mode_, kBaseImuRate / imu_rate_,
           BG1_QTN | BG1_IMU | BG1_MAG_PRES | BG1_SYNC_IN_CNT | BG1_TIME_SYNC_IN,
           BG3_NONE, BG5_NONE, true));
     } else {


### PR DESCRIPTION
add `binary_async_mode` param for `SERIAL_1` or `SERIAL_2`

usage:
`roslaunch imu_vn_100 vn_100_cont.launch binary_async_mode:="SERIAL_1"`
or
`roslaunch imu_vn_100 vn_100_cont.launch binary_async_mode:="SERIAL_2"`